### PR TITLE
Desciptor sets allocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = clang
 STD = -std=c99
 INCLUDES = -I src -I$(VULKAN_SDK)/include
-WARNINGS = -Wall -Wextra -Wno-c23-extensions -Wshadow -Wpointer-arith 			\
+WARNINGS = -Wall -Wextra -Wno-c2x-extensions -Wshadow -Wpointer-arith 			\
 		   -Wcast-align -Wsign-conversion -Wno-error=uninitialized
 MEMORYS = -fsanitize=address -fno-omit-frame-pointer
 

--- a/src/engine/renderer/vulkan/vk_device.c
+++ b/src/engine/renderer/vulkan/vk_device.c
@@ -314,12 +314,14 @@ b8 vk_device_init(vulkan_context_t *context) {
 		indices[idx++] = (uint32_t)context->device.transfer_idx;
 
 	VkDeviceQueueCreateInfo q_infos[32];
+	float queue_prior[32];
+
 	for (uint32_t i = 0; i < idx_count; ++i) {
+		queue_prior[i] = 1.0f;
 		q_infos[i].sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
 		q_infos[i].queueFamilyIndex = indices[i];
 		q_infos[i].queueCount = 1;
-		float q_prior = 1.0f;
-		q_infos[i].pQueuePriorities = &q_prior;
+		q_infos[i].pQueuePriorities = &queue_prior[i];
 	}
 
 	//TODO: implement this later
@@ -331,8 +333,8 @@ b8 vk_device_init(vulkan_context_t *context) {
 	create_info.pQueueCreateInfos = q_infos;
 	create_info.pEnabledFeatures = &dev_feats;
 	create_info.enabledExtensionCount = 1;
-	const char *ext_names = VK_KHR_SWAPCHAIN_EXTENSION_NAME;
-	create_info.ppEnabledExtensionNames = &ext_names;
+	static const char *ext_names[] = {VK_KHR_SWAPCHAIN_EXTENSION_NAME};
+	create_info.ppEnabledExtensionNames = ext_names;
 
 	/* Create Device */
 	VK_CHECK(vkCreateDevice(context->device.phys_dev, &create_info,

--- a/src/engine/renderer/vulkan/vk_type.h
+++ b/src/engine/renderer/vulkan/vk_type.h
@@ -127,13 +127,13 @@ typedef struct vulkan_object_shader_t {
 
 	VkDescriptorSetLayout global_desc_set_layout;
 	VkDescriptorPool global_desc_pool;
-	VkDescriptorSet global_desc_sets[4];
+	VkDescriptorSet *global_desc_sets;
 
 	vulkan_buffer_t global_uni_buffer;
 
 	global_uni_obj_t global_ubo;
 
-	b8 desc_updated[4];
+	b8 *desc_updated;
 } vulkan_object_shader_t;
 
 /* =========================== Vulkan Context =============================== */


### PR DESCRIPTION
Changes:
- Replaced the static array with a dynamic one.
- Ensures compatibility with cases where descriptor count is not known at compile time.

Note: Fixed-size array was causing issues when the descriptor count exceeded the predefined size. Use a dynamic array instead. Should be less prone to breaking. 