### PR TITLE
fix some bugs

### DIFF
--- a/src/engine/container/free_list.c
+++ b/src/engine/container/free_list.c
@@ -41,7 +41,7 @@ void return_node(freelist_t *freelist, freelist_node_t *node) {
 /* ========================================================================== */
 void freelist_init(uint64_t total_size, uint64_t *mem_require,
                           void *memory, freelist_t *freelist) {
-	uint64_t max_entry = (total_size / sizeof(void *));
+	uint64_t max_entry = (total_size / sizeof(freelist_node_t));
 	*mem_require = sizeof(internal_state_t) + (sizeof(freelist_node_t) * max_entry);
 	if (!memory) 
 		return;

--- a/src/engine/memory/dyn_alloc.c
+++ b/src/engine/memory/dyn_alloc.c
@@ -83,7 +83,7 @@ void *dyn_alloc_allocate(dyn_alloc_t *dyn_alloc, uint64_t size) {
 }
 
 b8 dyn_alloc_free(dyn_alloc_t *dyn_alloc, void *block, uint64_t size) {
-    if (!dyn_alloc || !block) {
+    if (!dyn_alloc || !block || !size) {
         ar_ERROR("dyn_alloc_free - require both a valid allocator (0x%p) and "
                  "block (0x%p) to be freed",
                  dyn_alloc, block);

--- a/src/engine/renderer/vulkan/vk_backend.c
+++ b/src/engine/renderer/vulkan/vk_backend.c
@@ -574,6 +574,8 @@ b8 vk_backend_begin_frame(render_backend_t *backend, float delta_time) {
 
 	context.main_render.render_area.z = context.framebuffer_w;
 	context.main_render.render_area.w = context.framebuffer_h;
+	context.ui_render.render_area.z = context.framebuffer_w;
+	context.ui_render.render_area.w = context.framebuffer_h;
 
     return true;
 }
@@ -616,7 +618,7 @@ b8 vk_backend_end_frame(render_backend_t *backend, float delta_time) {
     if (context.image_in_flight[context.image_idx] != 0) {
         VkResult result =
             vkWaitForFences(context.device.logic_dev, 1,
-                            context.image_in_flight[context.image_idx], true,
+                            &context.image_in_flight[context.image_idx], true,
                             UINT64_MAX);
         if (!vk_result_is_success(result)) {
             ar_FATAL("vkWaitForFences error: %s",
@@ -625,7 +627,7 @@ b8 vk_backend_end_frame(render_backend_t *backend, float delta_time) {
     }
 
     context.image_in_flight[context.image_idx] =
-        &context.in_flight_fence[context.current_frame];
+        context.in_flight_fence[context.current_frame];
     VK_CHECK(vkResetFences(context.device.logic_dev, 1,
                            &context.in_flight_fence[context.current_frame]));
 

--- a/src/engine/renderer/vulkan/vk_device.c
+++ b/src/engine/renderer/vulkan/vk_device.c
@@ -45,12 +45,21 @@ b8 query_queue_families(VkPhysicalDevice device, VkSurfaceKHR surface,
 	for (uint32_t i = 0; i < count; ++i) {
 		uint8_t score = 0;
 
-		if (props[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
-			out_info->graphic_family_idx = i;
-			++score;
-		}
+        if (out_info->graphic_family_idx == (uint32_t)-1 &&
+            props[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+            out_info->graphic_family_idx = i;
+            ++score;
 
-		if (props[i].queueFlags & VK_QUEUE_COMPUTE_BIT) {
+            VkBool32 support = VK_FALSE;
+            VK_CHECK(vkGetPhysicalDeviceSurfaceSupportKHR(device, i, surface,
+                                                          &support));
+            if (support) {
+                out_info->present_family_idx = i;
+                ++score;
+            }
+        }
+
+        if (props[i].queueFlags & VK_QUEUE_COMPUTE_BIT) {
 			out_info->compute_family_idx = i;
 			++score;
 		}

--- a/src/engine/renderer/vulkan/vk_type.h
+++ b/src/engine/renderer/vulkan/vk_type.h
@@ -246,7 +246,7 @@ typedef struct vulkan_context_t {
 	VkSemaphore *complete_semaphore;
 
 	VkFence in_flight_fence[3];
-	VkFence *image_in_flight[4];
+	VkFence image_in_flight[4];
 	VkFramebuffer world_framebuffer[4];
 
 	vulkan_buffer_t obj_vert_buffer;


### PR DESCRIPTION
- fix image_in_flight from VkFence *image_in_flight = VkFence image_in_flight.
- change freelist initialization from `uint64_t max_entry = (total_size / sizeof(void *));` to `uint64_t max_entry = (total_size / sizeof(freelist_node_t));`
- reworked queue selection logic to prefer pairing graphics/present to use the same queue.